### PR TITLE
get_parts.phpの画像アイコン表示処理No1

### DIFF
--- a/work/app/ImageAcqu.php
+++ b/work/app/ImageAcqu.php
@@ -4,7 +4,7 @@
  */
 class ImageAcqu
 {
-  
+
   /**
    * 画像表示
    * @paramreturn $result
@@ -50,20 +50,20 @@ class ImageAcqu
   /**
    * DB部品登録前画像取得処理
    * @param array $search
-   * @param array return 
+   * @param array return
    */
   public static function searchImage($search)
   {
     $result = false;
     $arr = [];
     $sql = "SELECT id FROM images WHERE name LIKE :name";
-    
+
     $search = $search[0];
     $search = '%'.$search.'%';
     $arr[] = $search;
 
     try {
-      $stmt = Database::connect()->prepare($sql); 
+      $stmt = Database::connect()->prepare($sql);
       $stmt->execute($arr);
       $result = $stmt->fetch();
       if (empty($result)) {
@@ -72,10 +72,10 @@ class ImageAcqu
       return $result;
     } catch(PDOException $e) {
       echo 'IMG_E01接続失敗' . $e->getMessage();
-      return $result; 
+      return $result;
     }
   }
-  
+
   /**
    * 画像登録処理
    * @param array $confirm
@@ -85,7 +85,7 @@ class ImageAcqu
   {
     $result = false;
     $arr = [];
-    
+
     //画像ファイル代入
     if (isset($_FILES['image']['tmp_name'])) {
       $file = $_FILES['image'];
@@ -103,18 +103,18 @@ class ImageAcqu
     }
 
     $sql = "INSERT INTO images (img_name, img_path, name) VALUES (?, ?, ?)";
-    
+
     $arr[] = $name;
     $arr[] = $save_path;
     $arr[] = $registparts['image_name'];
 
     try {
-      $stmt = Database::connect()->prepare($sql); 
+      $stmt = Database::connect()->prepare($sql);
       $result = $stmt->execute($arr);
       return $result;
     } catch(PDOException $e) {
       echo 'IMG_E02接続失敗' . $e->getMessage();
-      return $result; 
+      return $result;
     }
   }
 
@@ -126,19 +126,29 @@ class ImageAcqu
     $result = false;
     $arr = [];
 
-    $sql = "SELECT  img_path FROM images WHERE id = :id";
-    $arr[] = $getimg['image_id'];
-    // var_dump($arr);
-    try {
-      $stmt = Database::connect()->prepare($sql); 
-      $stmt->execute($arr);
-      $result = $stmt->fetch();
-      // var_dump($result);
-      // exit;
-      return $result;
-    } catch(PDOException $e) {
-      echo 'IMG_E03接続失敗' . $e->getMessage();
-      return $result; 
+    if (isset($getimg['image_id'])) {
+      $arr[] = $getimg['image_id'];
+      $sql = "SELECT img_path FROM images WHERE id = :id";
+      try {
+        $stmt = Database::connect()->prepare($sql);
+        $stmt->execute($arr);
+        $result = $stmt->fetch();
+        return $result;
+      } catch(PDOException $e) {
+        echo 'IMG_E03接続失敗' . $e->getMessage();
+        return $result;
+      }
+    } else {
+      $sql = "SELECT id, img_path FROM images";
+      try {
+        $stmt = Database::connect()->prepare($sql);
+        $stmt->execute($arr);
+        $result = $stmt->fetchAll();
+        return $result;
+      } catch (PDOException $e) {
+        echo 'IMG_E03接続失敗' . $e->getMessage();
+        return $result;
+      }
     }
   }
 }

--- a/work/app/PartsLogic.php
+++ b/work/app/PartsLogic.php
@@ -113,7 +113,7 @@ class PartsLogic
     //     break;
     // }
 
-    $sql = "SELECT id, partname FROM parts WHERE category LIKE ? ORDER BY id LIMIT ?, ?";
+    $sql = "SELECT id, partname,image_id FROM parts WHERE category LIKE ? ORDER BY id LIMIT ?, ?";
 
     // $search = $search['search_name'];
     $search = $search;
@@ -219,12 +219,12 @@ class PartsLogic
       // var_dump($result);
       // exit;
       if (!empty($result)) {
-       $getimg = ImageAcqu::getImage($result);
+        $getimg = ImageAcqu::getImage($result);
       //  var_dump($getimg);
-       $result = array_merge($result, $getimg);
+        $result = array_merge($result, $getimg);
       //  var_dump($result);
       //  exit;
-       return $result;
+        return $result;
       }
     } catch (PDOException $e) {
       echo 'PARTS_E04接続失敗' . $e->getMessage();

--- a/work/public/css/mypage.css
+++ b/work/public/css/mypage.css
@@ -16,6 +16,12 @@ img
   height: 80px;
 }
 
+.get-icon
+{
+  width: 150px;
+    height: 150px;
+}
+
 .bg1
 {
   background-color:rgb(146, 166, 185);

--- a/work/public/get_parts.php
+++ b/work/public/get_parts.php
@@ -37,6 +37,10 @@ if (!isset($_GET['page'])) {
 
 //検索パーツ取得
 $search = PartsLogic::searchParts($now, $per_page);
+$img = ImageAcqu::getImage(null); //画像id、パス全件取得
+$id_path = array_column((array)$img, 'img_path', 'id'); //idをキーにimg_pathを値にする
+$parts_img = array_column((array)$search, 'id', 'image_id'); //image_idをキーにする
+$image_path = array_intersect_key($id_path, $parts_img); //同じキーと値を取得
 
 //getpartsの配列から単一のカラムを返す
 if (!empty($search)) {
@@ -47,10 +51,12 @@ if (!empty($search)) {
   $search_srr = $_SESSION['search_err'];
   $num_data = 0;
 }
-
+var_dump($parts_id);
+var_dump($num_data);
+var_dump($image_path);
 //全データ件数表示
 $current = $now * $num_data;
-$total_num = '全' . $count[0] . '件中 ' . $current .'件';
+$total_num = '全' . $count[0] . '件中 ' . $current . '件';
 
 //検索結果から選ばれたパーツ formの値をセッションに保存
 if (!empty($_POST)) {
@@ -63,69 +69,82 @@ include('_header.php');
 
 ?>
 
-  <div class="container">
-    <?php if (!empty($search_srr)) : ?>
-      <h3 class="title-center">検索結果</h3>
-        <table class="table">
-          <thead>
-            <tr>
-              <th class="col-2">No</th>
-              <th class="col-10">品名</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><div class="h4 text-danger"><?= Utils::h($search_srr); ?></div></td>
-            </tr>
-          </tbody>
-        </table>
-        <form action="mypage.php" method="get">
-          <div class="container text-center">
-            <div class="d-flex flex-row-reverse">
-              <button class="btn btn-primary rounded-pill">戻る</button>
-            </div>
-          </div>
-        </form>
-    <?php else : ?>
-      <h1 class="h2 mb-1 mt-4 title-center">検索結果</h1>
-        <table class="table">
-          <thead>
-            <tr>
-
-              <th class="col">No</th>
-              <th class="col-11">品名</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      <?php $i = 1; foreach ((array)$parts_id as $key => $disp) : ?>
-        <form action="" method="post">
-          <ul class="list-unstyled parts-list">
-            <li class="lead ms-3"><?= $i .'. '; ?>
-            <button class="but btn-link ms-4"><?= Utils::h($disp); ?></button>
-            <input type="hidden" name="id" value="<?= Utils::h($key); ?>"></li>
-          </ul>
-        </form>
-      <?php $i++; endforeach; ?>
-
-      <div class="text-center mt-3 mb-2">
-        <p><?= Utils::h($total_num) ?></p>
-      </div>
-      <nav>
-        <ul class="pagination justify-content-center">
-          <?= Utils::h(Paging::paging($max_page, $now, 2, $url)); ?>
-        </ul>
-      </nav>
-
-      <form action="search.php" method="get">
-        <div class="container text-center">
-          <div class="d-flex flex-row-reverse">
-            <button class="btn btn-primary rounded-pill">戻る</button>
-          </div>
+<div class="container">
+  <?php if (!empty($search_srr)) : ?>
+    <h3 class="title-center">検索結果</h3>
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="col-2">No</th>
+          <th class="col-10">品名</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div class="h4 text-danger"><?= Utils::h($search_srr); ?></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <form action="mypage.php" method="get">
+      <div class="container text-center">
+        <div class="d-flex flex-row-reverse">
+          <button class="btn btn-primary rounded-pill">戻る</button>
         </div>
-      </form>
-    <?php endif; ?>
-  </div>
+      </div>
+    </form>
+  <?php else : ?>
+    <h1 class="h2 mb-1 mt-4 title-center">検索結果</h1>
+    <table class="table">
+      <thead>
+        <tr>
+          <!-- <th class="col">No</th>
+              <th class="col-11">品名</th> -->
+        </tr>
+      </thead>
+    </table>
+    <tbody></tbody>
+    <div class="d-flex flex-wrap">
+      <ul class="list-group">
+        <?php foreach ((array)$image_path as $path) : ?>
+          <li class="list-group-item">
+            <img class=" get-icon" src="<?= Utils::h($path); ?>" alt="">
+          </li>
+        <?php endforeach; ?>
+      </ul>
+      <ul>
+        <?php $i = 1; foreach ((array)$parts_id as $key => $disp) : ?>
+          <form action="" method="post">
+            <?= $i . '. '; ?>
+            <li class="list-group-item">
+              <button class="but btn-link ms-4"><?= Utils::h($disp); ?></button>
+              <input type="hidden" name="id" value="<?= Utils::h($key); ?>">
+            </li>
+          </form>
+        <?php $i++; endforeach; ?>
+      </ul>
+    </div>
+
+
+    <div class="text-center mt-3 mb-2">
+      <p><?= Utils::h($total_num) ?></p>
+    </div>
+    <nav>
+      <ul class="pagination justify-content-center">
+        <?= Utils::h(Paging::paging($max_page, $now, 2, $url)); ?>
+      </ul>
+    </nav>
+
+    <form action="search.php" method="get">
+      <div class="container text-center">
+        <div class="d-flex flex-row-reverse">
+          <button class="btn btn-primary rounded-pill">戻る</button>
+        </div>
+      </div>
+    </form>
+  <?php endif; ?>
+</div>
 
 <?php
-  include('_footer.php');
+include('_footer.php');

--- a/work/public/php_errors.log
+++ b/work/public/php_errors.log
@@ -12,3 +12,7 @@
 [30-Nov-2022 20:57:03 Asia/Tokyo] PHP Parse error:  syntax error, unexpected token "endif", expecting end of file in /work/public/admin.php on line 160
 [30-Nov-2022 20:57:06 Asia/Tokyo] PHP Parse error:  syntax error, unexpected token "endif", expecting end of file in /work/public/admin.php on line 160
 [30-Nov-2022 22:19:17 Asia/Tokyo] PHP Parse error:  syntax error, unexpected end of file, expecting "elseif" or "else" or "endif" in /work/public/mypage.php on line 164
+[21-Dec-2022 22:31:03 Asia/Tokyo] PHP Parse error:  syntax error, unexpected token ")" in /work/public/get_parts.php on line 104
+[21-Dec-2022 22:31:04 Asia/Tokyo] PHP Parse error:  syntax error, unexpected token ")" in /work/public/get_parts.php on line 104
+[21-Dec-2022 22:31:07 Asia/Tokyo] PHP Parse error:  syntax error, unexpected token ")" in /work/public/get_parts.php on line 104
+[21-Dec-2022 22:31:12 Asia/Tokyo] PHP Parse error:  syntax error, unexpected token ")" in /work/public/get_parts.php on line 104


### PR DESCRIPTION
＝編集内容＝
状況：部品カテゴリ検索から選択し検索結果一覧ページは部品名表示のみだった。

改善後：部品名と画像を表示させる

編集状況：今回の編集ではサーチパーツクラスから部品情報に画像 id も返すようにし
　　　　　画像 id から画像パスを取得し表示させた。

次回編集：HTMLで部品名と画像を整列させる。